### PR TITLE
Fix spelling error in manpage

### DIFF
--- a/data/laditools.1
+++ b/data/laditools.1
@@ -32,9 +32,9 @@ laditools \- tools to control and monitor LADI (JACK and ladish) systems
 .SH DESCRIPTION
 \fBLADITools\fP is a collection of tools aiming to achieve the goals of the
 LADI project to improve desktop integration and user workflow of GNU/Linux
-audio system based on JACK and LASH. Those tools take advantage of the
+audio system based on JACK and LASH. The tools take advantage of the
 D-Bus interfaces recently added to JACK and LASH to ease the configuration
-and use of those two great softwares.
+and use of those two great pieces of software.
 .PP
 The following tools are included:
 .TP


### PR DESCRIPTION
Fixes a spelling error found by the Lintian tool in Debian
