### PR TITLE
Add keywords to desktop files

### DIFF
--- a/data/ladi-control-center.desktop.in
+++ b/data/ladi-control-center.desktop.in
@@ -7,3 +7,4 @@ Exec=ladi-control-center
 Icon=preferences-system
 Categories=GNOME;GTK;Settings;
 _GenericName=LADI configuration
+_Keywords=Audio;JACK;Configuration;

--- a/data/ladi-player.desktop.in
+++ b/data/ladi-player.desktop.in
@@ -7,3 +7,4 @@ Exec=ladi-player
 Icon=ladi-player
 Categories=GTK;AudioVideo;Audio;
 _GenericName=LADI system controller
+_Keywords=Audio;JACK;Player;Studio;

--- a/data/ladi-system-log.desktop.in
+++ b/data/ladi-system-log.desktop.in
@@ -7,3 +7,4 @@ Exec=ladi-system-log
 Icon=ladi-system-log
 Categories=GNOME;GTK;Settings;
 _GenericName=Log file viewer
+_Keywords=Audio;JACK;Log Viewer;Ladish;a2jmidid;

--- a/data/ladi-system-tray.desktop.in
+++ b/data/ladi-system-tray.desktop.in
@@ -7,3 +7,4 @@ Exec=ladi-system-tray
 Icon=laditools
 Categories=GNOME;GTK;AudioVideo;
 _GenericName=LADI tray icon
+_Keywords=Audio;JACK;Player;Studio;Indicator;Start;Stop;Monitor;


### PR DESCRIPTION
Also fixing a Debian lintian error, this pull request adds keywords entries to the laditools desktop files.
